### PR TITLE
chore: ✂️ remove quotes from workflows inputs descriptions

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       comment:
-        description: "Comment to post on PR close"
+        description: Comment to post on PR close
         type: string
         required: true
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,17 +4,17 @@ on:
   workflow_call:
     inputs:
       sparse-checkout-cone-mode:
-        description: "Whether to use cone mode for sparse checkout"
+        description: Whether to use cone mode for sparse checkout
         type: boolean
         required: false
         default: false
       sparse-checkout:
-        description: "Files to checkout"
+        description: Files to checkout
         type: string
         required: false
-        default: "commitlint.config.js"
+        default: commitlint.config.js
       commitlint-help-url:
-        description: "URL with help on commit format rules"
+        description: URL with help on commit format rules
         type: string
         required: false
 


### PR DESCRIPTION
* Removed quotes from descriptions in `.github/workflows/pr-closed.yml` and `.github/workflows/pr-title.yml` for consistency.